### PR TITLE
fix: tool stores registered entities per instance

### DIFF
--- a/src/main/java/com/hanawa/animalfinder/item/custom/AnimalFinderToolItem.java
+++ b/src/main/java/com/hanawa/animalfinder/item/custom/AnimalFinderToolItem.java
@@ -28,7 +28,6 @@ import java.util.*;
 public class AnimalFinderToolItem extends Item {
     private final int distance;
     private final int maxSlots;
-    public final List<String> indexedEntities;
 
     private final String MODE_ALL = "animalfinder.tool.search_mode.all";
 
@@ -46,7 +45,12 @@ public class AnimalFinderToolItem extends Item {
         List<String> registeredEntities = getRegisteredEntities(item);
 
         tooltipComponents.add(Component.translatable("animalfinder.tool.tooltip.base"));
+        tooltipComponents.add(Component.literal("")); // line break
 
+        String searchMode = getSearchMode(item);
+        tooltipComponents.add(Component.translatable("animalfinder.tool.tooltip.search_mode", I18n.get(searchMode)));
+        tooltipComponents.add(Component.literal("")); // line break
+        
         if (registeredEntities.isEmpty()) {
             super.appendHoverText(item, level, tooltipComponents, isAdvanced);
             return;
@@ -118,6 +122,24 @@ public class AnimalFinderToolItem extends Item {
         CompoundTagUtil.putStringArray(tagCompound, STORAGE_KEY_INDEXED_ENTITIES, entities);
     }
 
+    /* Search mode */
+    private String getSearchMode(ItemStack item) {
+        CompoundTag tagCompound = item.getOrCreateTag();
+        String searchMode = tagCompound.getString(STORAGE_KEY_MODE);
+        if (searchMode.isBlank()) {
+            setSearchMode(item, MODE_ALL);
+
+            return MODE_ALL;
+        }
+
+        return searchMode;
+    }
+
+    private void setSearchMode(ItemStack item, String mode) {
+        CompoundTag tagCompound = item.getOrCreateTag();
+        tagCompound.putString(STORAGE_KEY_MODE, mode);
+    }
+
 
     /* Actions */
 
@@ -148,28 +170,23 @@ public class AnimalFinderToolItem extends Item {
     private void changeToolMode(Player player, ItemStack mainHandItem) {
         CompoundTag tagCompound = mainHandItem.getOrCreateTag();
 
-        String modeBeforeChange = tagCompound.getString(STORAGE_KEY_MODE);
-
-        if (modeBeforeChange.isBlank()) {
-            tagCompound.putString(STORAGE_KEY_MODE, MODE_ALL);
-            modeBeforeChange = MODE_ALL;
-        }
+        String modeBeforeChange = getSearchMode(mainHandItem);
 
         List<String> registeredEntities = getRegisteredEntities(mainHandItem);
         
         if(registeredEntities.size() > 1){
-            String currentMode = tagCompound.getString(STORAGE_KEY_MODE);
+            String currentMode = getSearchMode(mainHandItem);
             int currentModeIndex = registeredEntities.indexOf(currentMode);
 
             if (currentModeIndex == registeredEntities.size() - 1) {
-                tagCompound.putString(STORAGE_KEY_MODE, MODE_ALL);
+                setSearchMode(mainHandItem, MODE_ALL);
             } else {
-                tagCompound.putString(STORAGE_KEY_MODE, registeredEntities.get(currentModeIndex + 1));
+                setSearchMode(mainHandItem, registeredEntities.get(currentModeIndex + 1));
             }
         }
 
-        if (!modeBeforeChange.equals(tagCompound.getString(STORAGE_KEY_MODE))) {
-            sendMessage(player, "animalfinder.tool.message.search_mode_set", I18n.get(tagCompound.getString(STORAGE_KEY_MODE)));
+        if (!modeBeforeChange.equals(getSearchMode(mainHandItem))) {
+            sendMessage(player, "animalfinder.tool.message.search_mode_set", I18n.get(getSearchMode(mainHandItem)));
         }
     }
 

--- a/src/main/java/com/hanawa/animalfinder/util/CompoundTagUtil.java
+++ b/src/main/java/com/hanawa/animalfinder/util/CompoundTagUtil.java
@@ -1,0 +1,53 @@
+package com.hanawa.animalfinder.util;
+
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompoundTagUtil {
+    private static String getTotalItemsKey(String baseKey) {
+        return baseKey + "_TOTAL";
+    }
+
+    private static String getItemKey(String baseKey, int itemIndex) {
+        return baseKey + "_" + itemIndex;
+    }
+
+    public static List<String> getStringArray(CompoundTag tagCompound, String key) {
+        if (tagCompound == null) {
+            return new ArrayList<>();
+        }
+
+        int arraySize = tagCompound.getInt(getTotalItemsKey(key));
+        List<String> arrayItems = new ArrayList<>();
+
+        for(int index = 0; index < arraySize; index++) {
+            String entity = tagCompound.getString(getItemKey(key, index));
+
+            if (!entity.isBlank()) {
+                arrayItems.add(entity);
+            }
+        }
+
+        return arrayItems;
+    }
+
+    public static void putStringArray(@NotNull CompoundTag tagCompound, String key, List<String> entities) {
+        int arraySize = tagCompound.getInt(getTotalItemsKey(key));
+
+        // removes all registered entities
+        for(int index = 0; index < arraySize; index++) {
+            tagCompound.remove(getItemKey(key, index));
+        }
+
+        // register list again
+        for(int index = 0; index < entities.size(); index++) {
+            tagCompound.putString(getItemKey(key, index), entities.get(index));
+        }
+
+        tagCompound.putInt(getTotalItemsKey(key), entities.size());
+    }
+
+}

--- a/src/main/resources/assets/animalfinder/lang/en_us.json
+++ b/src/main/resources/assets/animalfinder/lang/en_us.json
@@ -14,5 +14,6 @@
   "animalfinder.tool.search_mode.all": "All",
   "animalfinder.tool.tooltip.base": "A tool that helps you find animals near you.",
   "animalfinder.tool.tooltip.one_animal": "Animals Included in the search: %s.",
-  "animalfinder.tool.tooltip.more_animals": "Animals Included in the search: %s, and %s."
+  "animalfinder.tool.tooltip.more_animals": "Animals Included in the search: %s, and %s.",
+  "animalfinder.tool.tooltip.search_mode": "The current search mode is: %s"
 }

--- a/src/main/resources/assets/animalfinder/lang/en_us.json
+++ b/src/main/resources/assets/animalfinder/lang/en_us.json
@@ -12,5 +12,7 @@
   "animalfinder.tool.message.search_result_empty": "No animal was found.",
   "animalfinder.tool.message.search_mode_set": "Search mode was set to '%s'",
   "animalfinder.tool.search_mode.all": "All",
-  "animalfinder.tool.tooltip": "A tool that helps you find animals near you. Animals Included in the search are: %s, and %s."
+  "animalfinder.tool.tooltip.base": "A tool that helps you find animals near you.",
+  "animalfinder.tool.tooltip.one_animal": " Animals Included in the search are: %s.",
+  "animalfinder.tool.tooltip.more_animals": " Animals Included in the search are: %s, and %s."
 }

--- a/src/main/resources/assets/animalfinder/lang/en_us.json
+++ b/src/main/resources/assets/animalfinder/lang/en_us.json
@@ -13,6 +13,6 @@
   "animalfinder.tool.message.search_mode_set": "Search mode was set to '%s'",
   "animalfinder.tool.search_mode.all": "All",
   "animalfinder.tool.tooltip.base": "A tool that helps you find animals near you.",
-  "animalfinder.tool.tooltip.one_animal": " Animals Included in the search are: %s.",
-  "animalfinder.tool.tooltip.more_animals": " Animals Included in the search are: %s, and %s."
+  "animalfinder.tool.tooltip.one_animal": "Animals Included in the search: %s.",
+  "animalfinder.tool.tooltip.more_animals": "Animals Included in the search: %s, and %s."
 }


### PR DESCRIPTION
Each tool item now have their own internal list of entities registered for them, as well as the search mode for it.

The tooltip information was also improved to contain that information.

https://github.com/Hanawa02/animal-finder/assets/11237366/4c57a417-3f97-4aab-afc2-8fbadbf9643c
